### PR TITLE
fix: operand error in L168, get image sample

### DIFF
--- a/src/stablediffusion/dream.py
+++ b/src/stablediffusion/dream.py
@@ -163,7 +163,7 @@ class StableDiffusionPipeline(DiffusionPipeline):
 
         # scale and decode the image latents with vae
         latents = 1 / 0.18215 * latents
-        image = self.vae.decode(latents)
+        image = self.vae.decode(latents).sample
 
         image = (image / 2 + 0.5).clamp(0, 1)
         image = image.cpu().permute(0, 2, 3, 1).numpy()


### PR DESCRIPTION
see similar line in huggingface repo pipeline https://github.com/huggingface/diffusers/blob/main/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py#L264