### PR TITLE
Updated README to reduce support headaches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,8 @@ dmypy.json
 # Pyre type checker
 .pyre/
 waifu-diffusion/
+
+# Modified personal files
+sd_run.bat
+wd_run.bat
+Dockerfile

--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@
 
 [![Discord Server](https://discordapp.com/api/guilds/930499730843250783/widget.png?style=banner2)](https://discord.gg/Sx6Spmsgx7)
 
+## Requirements
+Unlike some other projects built around Stable Diffusion this Discord bot is setup only for NVIDIA GPUs and not optimized for low VRAM hardware.
+Consult this table before attempting to run the bot:
+| VRAM  | Comment |
+| ------------- | ------------- |
+| 10GB+  | Recommended - bot will run fine |
+| 8GB-10GB  | Bot will most likely run |
+| 6GB-8GB  | Bot might run - issues expected |
+| <6GB  | Bot will probably not run, don't ask for support  |
 
 ## Setup
 Make sure you have the [CUDA Toolkit](https://developer.nvidia.com/cuda-downloads) installed

--- a/run.bat
+++ b/run.bat
@@ -1,1 +1,1 @@
-venv\Scripts\python.exe . --model_path "" --token=""
+venv\Scripts\python.exe . --model_path "" --token="" --hf_token=""

--- a/src/stablediffusion/ldm/generate.py
+++ b/src/stablediffusion/ldm/generate.py
@@ -112,7 +112,7 @@ class Generate:
             sampler_name          = 'k_lms',
             ddim_eta              = 0.0,  # deterministic
             precision             = 'autocast',
-            full_precision        = False,
+            full_precision        = True,
             strength              = 0.75,  # default in scripts/img2img.py
             seamless              = False,
             embedding_path        = None,


### PR DESCRIPTION
There is an increasing amount of low-spec users asking for support for the bot on Discord. Before they are disappointed or take up valuable support time I think it'd be best to list basic hardware requirements for VRAM in the README (inspired by a user suggestion).
Also, added --hf_token to the sample run.bat to match the run.sh script.